### PR TITLE
Fix arg name for baseurl

### DIFF
--- a/incubating/github-release/run.sh
+++ b/incubating/github-release/run.sh
@@ -91,7 +91,7 @@ function setDefaultVarValues() {
     fi
 
     if [ ! -z "$BASE_URL" ]; then
-        BASE_URL="--base-url $BASE_URL";
+        BASE_URL="--baseurl $BASE_URL";
     else 
         BASE_URL="";
     fi


### PR DESCRIPTION
When using the base url argument, the passed parameter was being ignored because the field in index.js is called `baseurl` not `base-url` https://github.com/codefresh-io/steps/blob/f8717de06093457efd5b6fdd4613f2736d332e52/incubating/github-release/github-release-cli/src/index.js#L18